### PR TITLE
feat: add dark mode styling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,12 +8,12 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="h-full bg-slate-50">
-      <body className="min-h-full text-slate-900">
-        <header className="border-b bg-white">
+    <html lang="en" className="dark h-full bg-slate-50 dark:bg-slate-900">
+      <body className="min-h-full bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100">
+        <header className="border-b bg-white dark:bg-slate-800 dark:border-slate-700">
           <div className="mx-auto max-w-4xl p-4 flex items-center justify-between">
-            <h1 className="text-xl font-bold">The road‑trip song game</h1>
-            <a className="text-sm underline" href="/api/auth/login">Sign in with Spotify</a>
+            <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">The road‑trip song game</h1>
+            <a className="text-sm underline text-slate-900 dark:text-slate-100" href="/api/auth/login">Sign in with Spotify</a>
           </div>
         </header>
         <main className="mx-auto max-w-4xl p-4">{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,10 @@ export default function Home() {
         <li>Tap “I don’t know” to reveal +5 seconds.</li>
         <li>1–4 players. Points: 1 for artist, 1 for song.</li>
       </ul>
-      <Link href="/game" className="inline-block rounded bg-black text-white px-4 py-2">
+      <Link
+        href="/game"
+        className="inline-block rounded bg-emerald-600 text-white px-4 py-2 hover:bg-emerald-700"
+      >
         Start playing
       </Link>
     </div>

--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -120,19 +120,19 @@ export default function Game({ players }: { players: string[] }) {
     <div className="space-y-6">
       <Scoreboard players={players} scores={scores} currentIndex={turnIndex} />
 
-      <div className="rounded border bg-white p-4 space-y-4">
+      <div className="rounded border bg-white p-4 space-y-4 dark:bg-slate-800 dark:border-slate-700">
         <h3 className="font-semibold">Pick an artist, genre, or playlist (paste a link)</h3>
         <SearchBox onPick={setTarget} />
       </div>
 
       {target && (
-        <div className="rounded border bg-white p-4 space-y-4">
+        <div className="rounded border bg-white p-4 space-y-4 dark:bg-slate-800 dark:border-slate-700">
           <div className="flex items-center justify-between">
             <div>
-              <div className="text-sm text-slate-600">
+              <div className="text-sm text-slate-600 dark:text-slate-400">
                 Round for: <b>{players[turnIndex]}</b>
               </div>
-              <div className="text-xs">
+              <div className="text-xs dark:text-slate-400">
                 Target:{" "}
                 <b>
                   {target.type === "genre"
@@ -144,18 +144,21 @@ export default function Game({ players }: { players: string[] }) {
               </div>
             </div>
             <div className="flex gap-2">
-              <button className="rounded border px-3 py-1" onClick={loadRandom}>
+              <button
+                className="rounded border px-3 py-1 dark:border-slate-600 dark:bg-slate-700"
+                onClick={loadRandom}
+              >
                 New random
               </button>
               <button
-                className="rounded bg-black text-white px-3 py-1"
+                className="rounded bg-emerald-600 text-white px-3 py-1 hover:bg-emerald-700"
                 onClick={playInitial}
                 disabled={!current?.uri || !ready}
               >
                 Play 1s
               </button>
               <button
-                className="rounded bg-slate-800 text-white px-3 py-1"
+                className="rounded bg-slate-700 text-white px-3 py-1"
                 onClick={extendFive}
                 disabled={!current?.uri || !ready || extended}
               >
@@ -164,26 +167,30 @@ export default function Game({ players }: { players: string[] }) {
             </div>
           </div>
 
-          {!current && <div className="text-sm text-slate-500">No track found. Try again.</div>}
+          {!current && (
+            <div className="text-sm text-slate-500 dark:text-slate-400">
+              No track found. Try again.
+            </div>
+          )}
 
           {current && (
             <>
               <div className="flex items-center gap-3">
                 {current.artwork && <img src={current.artwork} alt="" className="h-16 w-16 rounded" />}
-                <div className="text-sm text-slate-600">
+                <div className="text-sm text-slate-600 dark:text-slate-400">
                   Guess the <b>artist</b> and <b>song</b> name.
                 </div>
               </div>
 
               <div className="grid gap-2 sm:grid-cols-2">
                 <input
-                  className="rounded border px-3 py-2"
+                  className="rounded border px-3 py-2 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
                   placeholder="Artist"
                   value={guessArtist}
                   onChange={(e) => setGuessArtist(e.target.value)}
                 />
                 <input
-                  className="rounded border px-3 py-2"
+                  className="rounded border px-3 py-2 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
                   placeholder="Song"
                   value={guessSong}
                   onChange={(e) => setGuessSong(e.target.value)}
@@ -191,13 +198,16 @@ export default function Game({ players }: { players: string[] }) {
               </div>
 
               <div className="flex gap-2">
-                <button className="rounded bg-emerald-600 text-white px-4 py-2" onClick={submitGuesses}>
+                <button
+                  className="rounded bg-emerald-600 text-white px-4 py-2 hover:bg-emerald-700"
+                  onClick={submitGuesses}
+                >
                   Submit guess
                 </button>
 
                 {revealed && (
                   <button
-                    className="rounded border px-3 py-2"
+                    className="rounded border px-3 py-2 dark:border-slate-600 dark:bg-slate-700"
                     onClick={async () => {
                       setGuessArtist("");
                       setGuessSong("");
@@ -213,7 +223,11 @@ export default function Game({ players }: { players: string[] }) {
                 )}
 
                 {current.external_url && (
-                  <a className="ml-auto text-sm underline" href={current.external_url} target="_blank">
+                  <a
+                    className="ml-auto text-sm underline dark:text-slate-300"
+                    href={current.external_url}
+                    target="_blank"
+                  >
                     Open in Spotify
                   </a>
                 )}
@@ -221,14 +235,14 @@ export default function Game({ players }: { players: string[] }) {
 
               {/* Wrong banner */}
               {revealed && result === "wrong" && (
-                <div className="rounded border border-red-200 bg-red-50 p-3 text-red-700">
+                <div className="rounded border border-red-200 bg-red-50 p-3 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">
                   <div className="font-semibold">WRONG</div>
                 </div>
               )}
 
               {/* Always show the answer once revealed */}
               {revealed && (
-                <div className="rounded bg-emerald-50 border border-emerald-200 p-3">
+                <div className="rounded bg-emerald-50 border border-emerald-200 p-3 dark:bg-emerald-900 dark:border-emerald-700">
                   <div className="font-medium">Answer</div>
                   <div className="text-sm">
                     {current.artists.join(", ")} — {current.name}

--- a/components/PlayerSetup.tsx
+++ b/components/PlayerSetup.tsx
@@ -19,21 +19,33 @@ export default function PlayerSetup({ onStart }: { onStart: (players: string[]) 
     <div className="space-y-4">
       <h2 className="font-semibold text-lg">Players</h2>
       <label className="block">
-        <span className="text-sm">Number of players (1–4)</span>
-        <input type="number" min={1} max={4} value={count}
+        <span className="text-sm dark:text-slate-300">Number of players (1–4)</span>
+        <input
+          type="number"
+          min={1}
+          max={4}
+          value={count}
           onChange={(e) => updateCount(parseInt(e.target.value))}
-          className="mt-1 w-28 rounded border px-2 py-1" />
+          className="mt-1 w-28 rounded border px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+        />
       </label>
       <div className="grid gap-2">
         {Array.from({ length: count }).map((_, i) => (
-          <input key={i} className="rounded border px-2 py-1"
-            value={names[i]} onChange={(e) => {
+          <input
+            key={i}
+            className="rounded border px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+            value={names[i]}
+            onChange={(e) => {
               const v = e.target.value || `Player ${i + 1}`;
-              setNames((prev) => prev.map((p, idx) => idx === i ? v : p));
-            }} />
+              setNames((prev) => prev.map((p, idx) => (idx === i ? v : p)));
+            }}
+          />
         ))}
       </div>
-      <button onClick={() => onStart(names)} className="rounded bg-black text-white px-4 py-2">
+      <button
+        onClick={() => onStart(names)}
+        className="rounded bg-emerald-600 text-white px-4 py-2 hover:bg-emerald-700"
+      >
         Start game
       </button>
     </div>

--- a/components/Scoreboard.tsx
+++ b/components/Scoreboard.tsx
@@ -5,13 +5,20 @@ export default function Scoreboard({
   players, scores, currentIndex
 }: { players: string[]; scores: number[]; currentIndex: number; }) {
   return (
-    <div className="rounded border bg-white">
+    <div className="rounded border bg-white dark:bg-slate-800 dark:border-slate-700">
       <div className="grid grid-cols-2 sm:grid-cols-4">
         {players.map((p, i) => (
-          <div key={i} className={`p-3 border-r last:border-r-0 ${i===currentIndex ? "bg-amber-50" : ""}`}>
+          <div
+            key={i}
+            className={`p-3 border-r last:border-r-0 dark:border-slate-700 ${
+              i === currentIndex ? "bg-amber-50 dark:bg-amber-900" : ""
+            }`}
+          >
             <div className="text-xs uppercase tracking-wide">{p}</div>
             <div className="text-2xl font-bold">{scores[i] ?? 0}</div>
-            {i===currentIndex && <div className="text-xs text-amber-700">Your turn</div>}
+            {i === currentIndex && (
+              <div className="text-xs text-amber-700 dark:text-amber-300">Your turn</div>
+            )}
           </div>
         ))}
       </div>

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -81,52 +81,73 @@ export default function SearchBox({ onPick }: { onPick: (t: SearchTarget) => voi
   return (
     <div className="space-y-3">
       <div className="flex gap-2">
-        {(["artist", "genre", "playlist"] as const).map(t =>
-          <button key={t} onClick={() => setTab(t)}
-            className={`rounded-full px-3 py-1 border ${tab===t ? "bg-black text-white" : "bg-white"}`}>
+        {(["artist", "genre", "playlist"] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`rounded-full px-3 py-1 border dark:border-slate-600 ${
+              tab === t ? "bg-emerald-600 text-white" : "bg-white dark:bg-slate-700"
+            }`}
+          >
             {t}
           </button>
-        )}
+        ))}
       </div>
 
       <input
         value={q}
-        onChange={(e)=>setQ(e.target.value)}
+        onChange={(e) => setQ(e.target.value)}
         placeholder={tab === "playlist" ? "Search or paste playlist link..." : `Search ${tab}...`}
-        className="w-full rounded border px-3 py-2"
+        className="w-full rounded border px-3 py-2 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
       />
 
-      {loading && <div className="text-sm text-slate-500">Searching…</div>}
+      {loading && <div className="text-sm text-slate-500 dark:text-slate-400">Searching…</div>}
 
-      <ul className="divide-y rounded border bg-white">
-        {tab === "artist" && artistResults.map((r) => (
-          <li key={r.id} className="p-3 hover:bg-slate-50 cursor-pointer"
-              onClick={() => onPick({ type:"artist", id:r.id, name:r.name })}>
-            {r.name}
-          </li>
-        ))}
-        {tab === "playlist" && playlistResults.map((r) => (
-          <li key={r.id} className="p-3 hover:bg-slate-50 cursor-pointer"
-              onClick={() => onPick({ type:"playlist", id:r.id, name:r.name })}>
-            {r.name}
-          </li>
-        ))}
-        {tab === "genre" && genreResults.map((g) => (
-          <li key={g} className="p-3 hover:bg-slate-50 cursor-pointer"
-              onClick={() => onPick({ type:"genre", name:g })}>
-            {g}
-          </li>
-        ))}
+      <ul className="divide-y rounded border bg-white dark:bg-slate-800 dark:divide-slate-700 dark:border-slate-700">
+        {tab === "artist" &&
+          artistResults.map((r) => (
+            <li
+              key={r.id}
+              className="p-3 hover:bg-slate-50 dark:hover:bg-slate-700 cursor-pointer"
+              onClick={() => onPick({ type: "artist", id: r.id, name: r.name })}
+            >
+              {r.name}
+            </li>
+          ))}
+        {tab === "playlist" &&
+          playlistResults.map((r) => (
+            <li
+              key={r.id}
+              className="p-3 hover:bg-slate-50 dark:hover:bg-slate-700 cursor-pointer"
+              onClick={() => onPick({ type: "playlist", id: r.id, name: r.name })}
+            >
+              {r.name}
+            </li>
+          ))}
+        {tab === "genre" &&
+          genreResults.map((g) => (
+            <li
+              key={g}
+              className="p-3 hover:bg-slate-50 dark:hover:bg-slate-700 cursor-pointer"
+              onClick={() => onPick({ type: "genre", name: g })}
+            >
+              {g}
+            </li>
+          ))}
 
-        {!loading && q && (
-          (tab==="artist" && artistResults.length===0) ||
-          (tab==="playlist" && playlistResults.length===0) ||
-          (tab==="genre" && genreResults.length===0)
-        ) && (
-          <li className="p-3 text-sm text-slate-500">
-            No results{tab==="genre" ? " (tip: try seeds like pop, rock, hip-hop, metal, edm, country, jazz…)" : ""}.
-          </li>
-        )}
+        {!loading &&
+          q &&
+          ((tab === "artist" && artistResults.length === 0) ||
+            (tab === "playlist" && playlistResults.length === 0) ||
+            (tab === "genre" && genreResults.length === 0)) && (
+            <li className="p-3 text-sm text-slate-500 dark:text-slate-400">
+              No results
+              {tab === "genre"
+                ? " (tip: try seeds like pop, rock, hip-hop, metal, edm, country, jazz…)"
+                : ""}
+              .
+            </li>
+          )}
       </ul>
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
+  darkMode: "class",
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: { extend: {} },
   plugins: [require("@tailwindcss/forms")]


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode via `darkMode: "class"`
- default the app layout to dark and restyle core components for a dark theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aa486a00c483329bf33787dcf6d105