### PR TITLE
Filter playable Spotify tracks

### DIFF
--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -60,8 +60,17 @@ export async function randomTrackFromPlaylist(token: SpotifyToken, playlistId: s
 }
 
 function pickAnyPlayable(tracks: any[]) {
-  const ordered = shuffle(tracks ?? []);
-  const t = ordered.find((x:any)=> x && (x.type === "track" || x.uri)) || ordered[0];
+  const ordered = shuffle(
+    (tracks ?? []).filter((t: any) => {
+      if (!t) return false;
+      if (t.type !== "track") return false;
+      if (!t.uri) return false;
+      if (t.is_playable === false) return false;
+      if (t.is_local) return false;
+      return true;
+    })
+  );
+  const t = ordered[0];
   if (!t) return null;
   const artwork = t.album?.images?.[1]?.url ?? t.album?.images?.[0]?.url ?? null;
   return {


### PR DESCRIPTION
## Summary
- filter candidate Spotify items to only playable track entries before shuffling
- return null when no playable tracks remain so callers can handle the fallback

## Testing
- not run (requires manual Spotify playlist verification)


------
https://chatgpt.com/codex/tasks/task_e_68dcae2de9608332bb64efb519b75fda