### PR TITLE
Improve search selection UX and add priming feedback

### DIFF
--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -270,17 +270,20 @@ export default function Game({ players }: { players: string[] }) {
                 </b>
               </div>
             </div>
-            <div className="flex gap-2">
+            <div className="flex gap-2 items-start">
               <button className="rounded border border-gray-600 px-3 py-1 text-gray-100" onClick={loadRandom}>
                 New random
               </button>
-              <button
-                className="rounded border border-gray-600 px-3 py-1 text-gray-100"
-                onClick={primeCurrentTrack}
-                disabled={!current?.uri || !ready}
-              >
-                Load song
-              </button>
+              <div className="flex flex-col items-center">
+                <button
+                  className="rounded border border-gray-600 px-3 py-1 text-gray-100"
+                  onClick={primeCurrentTrack}
+                  disabled={!current?.uri || !ready}
+                >
+                  Load song
+                </button>
+                {primed && <span className="mt-1 text-[10px] uppercase tracking-wide text-emerald-400">song is primed</span>}
+              </div>
               <button
                 className="rounded bg-emerald-600 text-white px-3 py-1"
                 onClick={playInitial}
@@ -303,7 +306,14 @@ export default function Game({ players }: { players: string[] }) {
           {current && (
             <>
               <div className="flex items-center gap-3">
-                {current.artwork && <img src={current.artwork} alt="" className="h-16 w-16 rounded" />}
+                {current.artwork && (
+                  <img
+                    src={current.artwork}
+                    alt=""
+                    className="h-16 w-16 rounded object-cover"
+                    style={{ imageRendering: "pixelated" }}
+                  />
+                )}
                 <div className="text-sm text-gray-300">
                   Guess the <b>artist</b> and <b>song</b> name.
                 </div>

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -107,7 +107,11 @@ export default function SearchBox({ onPick }: { onPick: (t: SearchTarget) => voi
             <li
               key={r.id}
               className="p-3 hover:bg-gray-700 cursor-pointer"
-              onClick={() => onPick({ type: "artist", id: r.id, name: r.name })}
+              onClick={() => {
+                onPick({ type: "artist", id: r.id, name: r.name });
+                setQ("");
+                setArtistResults([]);
+              }}
             >
               {r.name}
             </li>
@@ -117,7 +121,11 @@ export default function SearchBox({ onPick }: { onPick: (t: SearchTarget) => voi
             <li
               key={r.id}
               className="p-3 hover:bg-gray-700 cursor-pointer"
-              onClick={() => onPick({ type: "playlist", id: r.id, name: r.name })}
+              onClick={() => {
+                onPick({ type: "playlist", id: r.id, name: r.name });
+                setQ("");
+                setPlaylistResults([]);
+              }}
             >
               {r.name}
             </li>
@@ -127,7 +135,11 @@ export default function SearchBox({ onPick }: { onPick: (t: SearchTarget) => voi
             <li
               key={g}
               className="p-3 hover:bg-gray-700 cursor-pointer"
-              onClick={() => onPick({ type: "genre", name: g })}
+              onClick={() => {
+                onPick({ type: "genre", name: g });
+                setQ("");
+                setGenreResults([]);
+              }}
             >
               {g}
             </li>


### PR DESCRIPTION
## Summary
- clear search results and reset the search query once a result is selected
- add a visible "song is primed" confirmation below the Load song button
- render track artwork with a pixelated effect for a more stylized look

## Testing
- npm run lint *(fails: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6901b8b766b08332857ca137b4f6e541