### PR TITLE
Improve pause reliability and blur album art

### DIFF
--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -310,8 +310,7 @@ export default function Game({ players }: { players: string[] }) {
                   <img
                     src={current.artwork}
                     alt=""
-                    className="h-16 w-16 rounded object-cover"
-                    style={{ imageRendering: "pixelated" }}
+                    className="h-16 w-16 rounded object-cover filter blur-sm"
                   />
                 )}
                 <div className="text-sm text-gray-300">

--- a/components/SpotifyPlayer.tsx
+++ b/components/SpotifyPlayer.tsx
@@ -290,7 +290,7 @@ export default function useSpotifyDevice() {
         }
 
         const state = await player.getCurrentState?.();
-        if (!state || state.paused) {
+        if (state?.paused) {
           sdkPauseSucceeded = true;
           break;
         }


### PR DESCRIPTION
## Summary
- prevent the Spotify pause helper from treating unknown playback state as a successful pause so playback always stops reliably
- add a light blur effect to the album artwork shown during guesses

## Testing
- not run (npm run lint prompts for interactive setup)

------
https://chatgpt.com/codex/tasks/task_e_6901bf17609883328ba80f8a4364287d