### PR TITLE
Ensure pause helper confirms playback stops

### DIFF
--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -191,8 +191,16 @@ export default function Game({ players }: { players: string[] }) {
     await playUriAt(current.uri, 0);
     await resumePlayback();
     await waitForPlaybackStart();
-    await pausePlayback();
-    setPrimed(true);
+    try {
+      const paused = await pausePlayback();
+      if (!paused) {
+        console.warn("Unable to prime track: playback never paused");
+        return;
+      }
+      setPrimed(true);
+    } catch (error) {
+      console.warn("Unable to prime track: pause request failed", error);
+    }
   }
 
   async function playInitial() {
@@ -202,8 +210,18 @@ export default function Game({ players }: { players: string[] }) {
     clearPauseTimeout();
     await waitForPlaybackStart();
     pauseTimeoutRef.current = window.setTimeout(() => {
-      pausePlayback();
-      pauseTimeoutRef.current = null;
+      void pausePlayback()
+        .then((paused) => {
+          if (!paused) {
+            console.warn("Timed pause after 1s did not confirm");
+          }
+        })
+        .catch((error) => {
+          console.warn("Timed pause after 1s failed", error);
+        })
+        .finally(() => {
+          pauseTimeoutRef.current = null;
+        });
     }, 1000);
   }
 
@@ -215,8 +233,18 @@ export default function Game({ players }: { players: string[] }) {
     await waitForPlaybackStart();
     setExtended(true);
     pauseTimeoutRef.current = window.setTimeout(() => {
-      pausePlayback();
-      pauseTimeoutRef.current = null;
+      void pausePlayback()
+        .then((paused) => {
+          if (!paused) {
+            console.warn("Timed pause after 5s did not confirm");
+          }
+        })
+        .catch((error) => {
+          console.warn("Timed pause after 5s failed", error);
+        })
+        .finally(() => {
+          pauseTimeoutRef.current = null;
+        });
     }, 5000);
   }
 


### PR DESCRIPTION
## Summary
- update the Spotify pause helper to return a boolean and poll the SDK state before reporting success
- surface failures from the Next.js pause fallback so callers can react to real pause errors
- gate Game component state changes and timers on confirmed pauses and log when a pause cannot complete

## Testing
- not run (Next.js lint prompts for interactive configuration in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6901c5f2edd4833294d7a3cf83244c0b